### PR TITLE
Allow for more advanced substituting

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -46,7 +46,7 @@ impl CookieStore for HitmanCookieJar {
                 let headers = arr
                     .iter()
                     .filter_map(|it| cookie::Cookie::parse(it.as_str()?).ok())
-                    .map(|cookie| format!("{}={}", cookie.name(), cookie.value()).to_string())
+                    .map(|cookie| format!("{}={}", cookie.name(), cookie.value()))
                     .collect::<Vec<_>>()
                     .join("; ");
 


### PR DESCRIPTION
Also removing an unnecessary `to_string()` from the last PR about cookie store